### PR TITLE
ci: pin Elixir and Rebar3 versions

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -45,7 +45,9 @@ jobs:
       - uses: erlef/setup-beam@v1
         with:
           otp-version: "28"
+          elixir-version: "1.18.x"
           gleam-version: "1.16.0"
+          rebar3-version: "3"
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
Pin Elixir version to 1.18.x and Rebar3 version to 3 in the
deployment workflow. This ensures consistent build environments
across CI runs and prevents unexpected behavior from version
drift.