### PR TITLE
fix: correct asset paths for GitHub Pages

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -57,6 +57,11 @@ jobs:
       - name: Build web
         run: gleam run -m lustre/dev build --minify
         working-directory: packages/web
+      - name: Fix asset paths for GitHub Pages subdirectory
+        working-directory: packages/web/dist
+        run: |
+          sed -i 's|"/bygg_web\.|"./bygg_web.|g' index.html
+          sed -i "s|'/bygg_web\.|'./bygg_web.|g" index.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: packages/web/dist


### PR DESCRIPTION
Add step to fix asset paths in built HTML for GitHub Pages
subdirectory deployment. Replace absolute paths starting
with "/bygg_web." with relative paths "./bygg_web." to
ensure assets load correctly when served from a
subdirectory rather than the root domain.