### PR TITLE
fix: correct logo asset paths in web build

### DIFF
--- a/.github/workflows/deploy-web.yml
+++ b/.github/workflows/deploy-web.yml
@@ -62,6 +62,8 @@ jobs:
         run: |
           sed -i 's|"/bygg_web\.|"./bygg_web.|g' index.html
           sed -i "s|'/bygg_web\.|'./bygg_web.|g" index.html
+          sed -i 's|"/logo\.|"./logo.|g' index.html
+          sed -i "s|'/logo\.|'./logo.|g" index.html
       - uses: actions/upload-pages-artifact@v3
         with:
           path: packages/web/dist


### PR DESCRIPTION
Update the web deployment workflow to fix relative paths
for logo assets in the built index.html file. Add sed
commands to replace absolute logo paths with relative
paths, matching the existing pattern used for bygg_web
assets. This ensures logo assets load correctly when
deployed to GitHub Pages.