### PR TITLE
chore: bump web package version to 0.0.2

### DIFF
--- a/packages/web/gleam.toml
+++ b/packages/web/gleam.toml
@@ -1,5 +1,5 @@
 name = "bygg_web"
-version = "0.0.1"
+version = "0.0.2"
 target = "javascript"
 
 [javascript]

--- a/packages/web/src/bygg_web/view/success.gleam
+++ b/packages/web/src/bygg_web/view/success.gleam
@@ -35,7 +35,7 @@ pub fn render(model: Model, project_name: String) -> Element(Msg) {
           class(
             "px-6 py-2.5 rounded-full text-sm font-semibold border border-stone-300 text-stone-600 hover:bg-stone-50 transition-colors",
           ),
-          href("https://gleam.run/getting-started/"),
+          href("https://gleam.run/documentation/"),
           attribute("target", "_blank"),
           attribute("rel", "noopener noreferrer"),
         ],


### PR DESCRIPTION
Update the Gleam documentation link in the success view
from the getting-started guide to the main documentation
page to provide users with more comprehensive resources.