### PR TITLE
refactor: remove deprecated packages from catalog

### DIFF
--- a/packages/core/src/bygg/catalog.gleam
+++ b/packages/core/src/bygg/catalog.gleam
@@ -116,22 +116,13 @@ pub fn packages() -> List(Package) {
     ),
     Package(
       ..default(
-        name: "simplifile",
-        hex_name: "simplifile",
-        description: "Simple file I/O for Gleam",
-        default_constraint: ">= 2.4.0 and < 3.0.0",
-      ),
-      targets: ErlangOnly,
-      repository: "https://github.com/gleam-lang/simplifile",
-    ),
-    Package(
-      ..default(
         name: "envoy",
         hex_name: "envoy",
         description: "Environment variable access for Gleam",
         default_constraint: ">= 1.0.0 and < 2.0.0",
       ),
       repository: "https://github.com/lpil/envoy",
+      is_hidden: True,
     ),
     Package(
       ..default(
@@ -266,29 +257,6 @@ pub fn packages() -> List(Package) {
       dev_only: True,
       is_hidden: True,
       repository: "https://github.com/jtdowney/unitest",
-    ),
-    Package(
-      ..default(
-        name: "birdie",
-        hex_name: "birdie",
-        description: "Snapshot testing for Gleam",
-        default_constraint: ">= 1.0.0 and < 2.0.0",
-      ),
-      category: Testing,
-      dev_only: True,
-      repository: "https://github.com/bcpeinhardt/birdie",
-    ),
-    Package(
-      ..default(
-        name: "squirrel",
-        hex_name: "squirrel",
-        description: "Type-safe SQL in Gleam",
-        default_constraint: ">= 4.4.0 and < 5.0.0",
-      ),
-      targets: ErlangOnly,
-      category: Database,
-      dev_only: True,
-      repository: "https://github.com/giacomocavalieri/squirrel",
     ),
     Package(
       ..default(

--- a/packages/core/test/integration_docker_test.gleam
+++ b/packages/core/test/integration_docker_test.gleam
@@ -69,15 +69,6 @@ pub fn webserver_pog_gleam_json_test() {
   )
 }
 
-pub fn webserver_pog_envoy_test() {
-  use <- unitest.tag("docker")
-  check_and_test(
-    config.default("t_web_pog_envoy")
-      |> with_deps(["wisp", "mist", "pog", "envoy"]),
-    "webserver_pog_envoy_test",
-  )
-}
-
 pub fn lustre_server_component_pog_test() {
   use <- unitest.tag("docker")
   check_and_test(

--- a/packages/core/test/integration_no_docker_test.gleam
+++ b/packages/core/test/integration_no_docker_test.gleam
@@ -1,7 +1,5 @@
 import bygg/config
-import integration_helpers.{
-  check_and_test, compile_only, javascript, with_deps, with_dev_deps,
-}
+import integration_helpers.{check_and_test, compile_only, javascript, with_deps}
 import unitest
 
 pub fn basic_app_test() {
@@ -92,24 +90,6 @@ pub fn basic_gleam_otp_test() {
   check_and_test(
     config.default("t_basic_otp") |> with_deps(["gleam_otp"]),
     "basic_gleam_otp_test",
-  )
-}
-
-pub fn basic_birdie_test() {
-  use <- unitest.tag("no_docker")
-  check_and_test(
-    config.default("t_basic_birdie") |> with_dev_deps(["birdie"]),
-    "basic_birdie_test",
-  )
-}
-
-pub fn webserver_birdie_test() {
-  use <- unitest.tag("no_docker")
-  check_and_test(
-    config.default("t_web_birdie")
-      |> with_deps(["wisp", "mist"])
-      |> with_dev_deps(["birdie"]),
-    "webserver_birdie_test",
   )
 }
 


### PR DESCRIPTION
Remove simplifile, birdie, and squirrel packages from the
catalog as they are easy to add manually. Great libs, but not suitable for bygg. Remove associated integration tests for
birdie and the webserver_pog_envoy test case.