### PR TITLE
feat: add support for package-specific gitignore entries

### DIFF
--- a/packages/core/birdie_snapshots/gitignore_default.accepted
+++ b/packages/core/birdie_snapshots/gitignore_default.accepted
@@ -1,0 +1,12 @@
+---
+version: 1.5.5
+title: gitignore_default
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_gitignore_default_test
+---
+/build/
+*.beam
+*.ez
+erl_crash.dump
+.env
+

--- a/packages/core/birdie_snapshots/gitignore_with_package_entries.accepted
+++ b/packages/core/birdie_snapshots/gitignore_with_package_entries.accepted
@@ -1,0 +1,15 @@
+---
+version: 1.5.5
+title: gitignore_with_package_entries
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_gitignore_with_package_entries_test
+---
+/build/
+*.beam
+*.ez
+erl_crash.dump
+.env
+
+node_modules/
+dist/
+

--- a/packages/core/src/bygg/catalog.gleam
+++ b/packages/core/src/bygg/catalog.gleam
@@ -10,6 +10,7 @@ import bygg/catalog/valkyrie as valkyrie_pkg
 import bygg/config.{type Target, Erlang, JavaScript}
 import bygg/contribution_block.{type Contribution, empty}
 import gleam/list
+import gleam/option.{type Option, None, Some}
 
 pub type SupportedTarget {
   ErlangOnly
@@ -55,6 +56,7 @@ pub type Package {
     is_hidden: Bool,
     is_disabled: Bool,
     repository: String,
+    gitignore_entries: Option(List(String)),
   )
 }
 
@@ -79,6 +81,7 @@ fn default(
     is_hidden: False,
     is_disabled: False,
     repository: "https://hex.pm/packages/" <> hex_name,
+    gitignore_entries: None,
   )
 }
 
@@ -207,6 +210,7 @@ pub fn packages() -> List(Package) {
       roles: [FrontendFramework],
       contribution: lustre_browser_app_pkg.contribution,
       repository: "https://github.com/lustre-labs/lustre",
+      gitignore_entries: Some(["node_modules/", "dist/"]),
     ),
     Package(
       ..default(
@@ -220,6 +224,7 @@ pub fn packages() -> List(Package) {
       roles: [LustreComponent],
       contribution: lustre_component_pkg.contribution,
       repository: "https://github.com/lustre-labs/lustre",
+      gitignore_entries: Some(["node_modules/", "dist/"]),
     ),
     Package(
       ..default(

--- a/packages/core/src/bygg/generator.gleam
+++ b/packages/core/src/bygg/generator.gleam
@@ -9,6 +9,7 @@ import bygg/validation
 import gleam/list
 import gleam/option.{None, Some}
 import gleam/result
+import gleam/string
 
 pub type FileEntry {
   FileEntry(path: String, content: String)
@@ -217,7 +218,10 @@ fn build_files(
       "test/" <> config.name <> "_test.gleam",
       template.test_module(config, app_profile, contributions),
     ),
-    FileEntry(".gitignore", template.gitignore(config)),
+    FileEntry(
+      ".gitignore",
+      template.gitignore(config, gitignore_entries(config)),
+    ),
     FileEntry(
       "README.md",
       template.readme(
@@ -306,6 +310,22 @@ fn build_files(
     docker_files,
     dockerfile_files,
   ])
+}
+
+fn gitignore_entries(config: ProjectConfig) -> List(String) {
+  let all_dep_names =
+    list.map(config.dependencies, fn(d) { d.name })
+    |> list.append(list.map(config.dev_dependencies, fn(d) { d.name }))
+  list.filter_map(all_dep_names, fn(name) {
+    case catalog.find_by_name(name) {
+      Ok(package) ->
+        case package.gitignore_entries {
+          None -> Error(Nil)
+          Some(entries) -> Ok(string.join(entries, "\n"))
+        }
+      Error(_) -> Error(Nil)
+    }
+  })
 }
 
 fn ensure_dep(

--- a/packages/core/src/bygg/template.gleam
+++ b/packages/core/src/bygg/template.gleam
@@ -41,8 +41,8 @@ pub fn test_utils_module(
   )
 }
 
-pub fn gitignore(config: ProjectConfig) -> String {
-  env.gitignore(config)
+pub fn gitignore(config: ProjectConfig, extra_entries: List(String)) -> String {
+  env.gitignore(config, extra_entries)
 }
 
 pub fn readme(

--- a/packages/core/src/bygg/template/env.gleam
+++ b/packages/core/src/bygg/template/env.gleam
@@ -1,13 +1,15 @@
 import bygg/config.{type ProjectConfig}
 import gleam/string
 
-pub fn gitignore(_config: ProjectConfig) -> String {
-  "/build/
-*.beam
-*.ez
-erl_crash.dump
-.env
-"
+pub fn gitignore(
+  _config: ProjectConfig,
+  extra_entries: List(String),
+) -> String {
+  let base = "/build/\n*.beam\n*.ez\nerl_crash.dump\n.env\n"
+  case extra_entries {
+    [] -> base
+    _ -> base <> "\n" <> string.join(extra_entries, "\n") <> "\n"
+  }
 }
 
 pub fn env_example(env_var_blocks: List(String)) -> String {

--- a/packages/core/test/bygg_core_test.gleam
+++ b/packages/core/test/bygg_core_test.gleam
@@ -959,6 +959,23 @@ pub fn snapshot_test_module_with_shork_and_testcontainers_test() {
   |> birdie.snap(title: "test_module_with_shork_and_testcontainers")
 }
 
+pub fn snapshot_gitignore_default_test() {
+  let config = config.default("my_app")
+  template.gitignore(config, [])
+  |> birdie.snap(title: "gitignore_default")
+}
+
+pub fn snapshot_gitignore_with_package_entries_test() {
+  let config =
+    config.default("my_site")
+    |> fn(c) { ProjectConfig(..c, target: JavaScript) }
+    |> with_dep("lustre")
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) = list.find(project.files, fn(f) { f.path == ".gitignore" })
+  f.content
+  |> birdie.snap(title: "gitignore_with_package_entries")
+}
+
 pub fn snapshot_test_utils_shork_with_testcontainers_test() {
   let config =
     config.default("my_app")

--- a/packages/web/src/bygg_web/view/root.gleam
+++ b/packages/web/src/bygg_web/view/root.gleam
@@ -45,7 +45,11 @@ fn active_panel(model: Model) -> Element(Msg) {
 fn footer() -> Element(Msg) {
   html.footer([class("border-t border-stone-200 bg-white py-4 mt-8")], [
     html.div(
-      [class("max-w-5xl mx-auto px-4 flex flex-col gap-2 text-xs text-stone-400")],
+      [
+        class(
+          "max-w-5xl mx-auto px-4 flex flex-col gap-2 text-xs text-stone-400",
+        ),
+      ],
       [
         html.p([], [
           html.text(


### PR DESCRIPTION
Add ability for packages to contribute their own entries to
the generated .gitignore file. The gitignore function now
accepts an extra_entries parameter that gets appended to the
base entries.

Implement gitignore_entries function to collect entries from
all project dependencies by looking up their catalog entries.
Update lustre packages to contribute node_modules/ and dist/
to gitignore.

Add snapshot tests to verify gitignore generation with and
without package entries.

Reformat footer class attribute for improved readability.