### PR TITLE
feat: add CI provider selection to wizard

### DIFF
--- a/packages/cli/src/bygg_cli/cli.gleam
+++ b/packages/cli/src/bygg_cli/cli.gleam
@@ -184,8 +184,8 @@ fn resolve_packages(names: List(String)) -> List(SelectedPackage) {
       Ok(package) ->
         SelectedPackage(
           package.name,
-          package.hex_name,
-          package.default_constraint,
+          option.unwrap(package.hex_name, package.name),
+          option.unwrap(package.default_constraint, ">= 1.0.0 and < 2.0.0"),
         )
       Error(_) -> SelectedPackage(name, name, ">= 1.0.0 and < 2.0.0")
     }
@@ -228,7 +228,11 @@ pub fn list_deps_command() -> glint.Command(Nil) {
             True -> ansi.dim(" (dev)")
             False -> ""
           }
-          io.println("    " <> ansi.cyan(package.hex_name) <> dev_label)
+          io.println(
+            "    "
+            <> ansi.cyan(option.unwrap(package.hex_name, package.name))
+            <> dev_label,
+          )
           io.println(ansi.dim("      " <> package.description))
         })
         io.println("")

--- a/packages/core/birdie_snapshots/ci_circleci.accepted
+++ b/packages/core/birdie_snapshots/ci_circleci.accepted
@@ -1,0 +1,25 @@
+---
+version: 1.5.5
+title: ci_circleci
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_circleci_test
+---
+version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: ghcr.io/gleam-lang/gleam:v1.16.0-erlang
+    steps:
+      - checkout
+      - run:
+          name: Install rebar3
+          command: apt-get update && apt-get install -y rebar3
+      - run: gleam build
+      - run: gleam test
+
+workflows:
+  ci:
+    jobs:
+      - test
+

--- a/packages/core/birdie_snapshots/ci_circleci_with_testcontainers.accepted
+++ b/packages/core/birdie_snapshots/ci_circleci_with_testcontainers.accepted
@@ -1,0 +1,29 @@
+---
+version: 1.5.5
+title: ci_circleci_with_testcontainers
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_circleci_with_testcontainers_test
+---
+version: 2.1
+
+jobs:
+  test:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - checkout
+      - run:
+          name: Install Gleam
+          command: |
+            curl -fsSL https://github.com/gleam-lang/gleam/releases/download/v1.16.0/gleam-v1.16.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin
+      - run:
+          name: Install rebar3 and Elixir
+          command: apt-get update && apt-get install -y rebar3 elixir
+      - run: gleam build
+      - run: gleam test
+
+workflows:
+  ci:
+    jobs:
+      - test
+

--- a/packages/core/birdie_snapshots/ci_github_actions.accepted
+++ b/packages/core/birdie_snapshots/ci_github_actions.accepted
@@ -1,0 +1,27 @@
+---
+version: 1.5.5
+title: ci_github_actions
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_github_actions_test
+---
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          rebar3-version: "3"
+          gleam-version: "1.16.0"
+      - run: gleam build
+      - run: gleam test
+

--- a/packages/core/birdie_snapshots/ci_github_actions_with_testcontainers.accepted
+++ b/packages/core/birdie_snapshots/ci_github_actions_with_testcontainers.accepted
@@ -1,0 +1,28 @@
+---
+version: 1.5.5
+title: ci_github_actions_with_testcontainers
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_github_actions_with_testcontainers_test
+---
+name: CI
+
+on:
+  push:
+    branches: ["main"]
+  pull_request:
+    branches: ["main"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: "27"
+          rebar3-version: "3"
+          gleam-version: "1.16.0"
+          elixir-version: "1.17"
+      - run: gleam build
+      - run: gleam test
+

--- a/packages/core/birdie_snapshots/ci_gitlab.accepted
+++ b/packages/core/birdie_snapshots/ci_gitlab.accepted
@@ -1,0 +1,16 @@
+---
+version: 1.5.5
+title: ci_gitlab
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_gitlab_test
+---
+image: ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine
+
+before_script:
+  - apk add --no-cache rebar3
+
+test:
+  script:
+    - gleam build
+    - gleam test
+

--- a/packages/core/birdie_snapshots/ci_gitlab_with_testcontainers.accepted
+++ b/packages/core/birdie_snapshots/ci_gitlab_with_testcontainers.accepted
@@ -1,0 +1,23 @@
+---
+version: 1.5.5
+title: ci_gitlab_with_testcontainers
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_gitlab_with_testcontainers_test
+---
+image: ghcr.io/gleam-lang/gleam:v1.16.0-erlang-alpine
+
+services:
+  - docker:dind
+
+variables:
+  DOCKER_HOST: tcp://docker:2376
+  DOCKER_TLS_CERTDIR: "/certs"
+
+before_script:
+  - apk add --no-cache rebar3 elixir docker-cli
+
+test:
+  script:
+    - gleam build
+    - gleam test
+

--- a/packages/core/birdie_snapshots/ci_travisci.accepted
+++ b/packages/core/birdie_snapshots/ci_travisci.accepted
@@ -1,0 +1,17 @@
+---
+version: 1.5.5
+title: ci_travisci
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_travisci_test
+---
+language: erlang
+otp_release:
+  - "27"
+
+before_install:
+  - curl -fsSL https://github.com/gleam-lang/gleam/releases/download/v1.16.0/gleam-v1.16.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin
+
+script:
+  - gleam build
+  - gleam test
+

--- a/packages/core/birdie_snapshots/ci_travisci_with_testcontainers.accepted
+++ b/packages/core/birdie_snapshots/ci_travisci_with_testcontainers.accepted
@@ -1,0 +1,21 @@
+---
+version: 1.5.5
+title: ci_travisci_with_testcontainers
+file: ./test/bygg_core_test.gleam
+test_name: snapshot_ci_travisci_with_testcontainers_test
+---
+language: erlang
+otp_release:
+  - "27"
+
+services:
+  - docker
+
+before_install:
+  - curl -fsSL https://github.com/gleam-lang/gleam/releases/download/v1.16.0/gleam-v1.16.0-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin
+  - sudo apt-get update && sudo apt-get install -y elixir
+
+script:
+  - gleam build
+  - gleam test
+

--- a/packages/core/src/bygg/catalog.gleam
+++ b/packages/core/src/bygg/catalog.gleam
@@ -29,6 +29,7 @@ pub type Category {
   Crypto
   Logging
   Telemetry
+  Ci
 }
 
 pub type Role {
@@ -43,9 +44,9 @@ pub type Role {
 pub type Package {
   Package(
     name: String,
-    hex_name: String,
+    hex_name: Option(String),
     description: String,
-    default_constraint: String,
+    default_constraint: Option(String),
     targets: SupportedTarget,
     min_gleam_version: String,
     category: Category,
@@ -68,9 +69,9 @@ fn default(
 ) {
   Package(
     name: name,
-    hex_name: hex_name,
+    hex_name: Some(hex_name),
     description: description,
-    default_constraint: default_constraint,
+    default_constraint: Some(default_constraint),
     targets: BothTargets,
     min_gleam_version: "1.0.0",
     category: Utilities,
@@ -81,6 +82,30 @@ fn default(
     is_hidden: False,
     is_disabled: False,
     repository: "https://hex.pm/packages/" <> hex_name,
+    gitignore_entries: None,
+  )
+}
+
+fn default_ci(
+  name name: String,
+  description description: String,
+  docs_url docs_url: String,
+) {
+  Package(
+    name: name,
+    hex_name: None,
+    description: description,
+    default_constraint: None,
+    targets: BothTargets,
+    min_gleam_version: "1.0.0",
+    category: Ci,
+    dev_only: False,
+    requires_otp: False,
+    roles: [],
+    contribution: empty,
+    is_hidden: False,
+    is_disabled: False,
+    repository: docs_url,
     gitignore_entries: None,
   )
 }
@@ -327,6 +352,26 @@ pub fn packages() -> List(Package) {
       contribution: carrote_pkg.contribution,
       repository: "https://github.com/renatillas/carotte",
     ),
+    default_ci(
+      name: "github_actions",
+      description: "GitHub Actions CI workflow (.github/workflows/ci.yml)",
+      docs_url: "https://docs.github.com/en/actions",
+    ),
+    default_ci(
+      name: "gitlab_ci",
+      description: "GitLab CI/CD pipeline (.gitlab-ci.yml)",
+      docs_url: "https://docs.gitlab.com/ci/",
+    ),
+    default_ci(
+      name: "circleci",
+      description: "CircleCI pipeline (.circleci/config.yml)",
+      docs_url: "https://circleci.com/docs/",
+    ),
+    default_ci(
+      name: "travisci",
+      description: "Travis CI pipeline (.travis.yml)",
+      docs_url: "https://docs.travis-ci.com/",
+    ),
   ]
 }
 
@@ -347,7 +392,7 @@ pub fn by_category(category: Category) -> List(Package) {
 }
 
 pub fn find_by_hex_name(hex_name: String) -> Result(Package, Nil) {
-  list.find(packages(), fn(package) { package.hex_name == hex_name })
+  list.find(packages(), fn(package) { package.hex_name == Some(hex_name) })
 }
 
 pub fn find_by_name(name: String) -> Result(Package, Nil) {
@@ -379,6 +424,7 @@ pub fn all_categories() -> List(Category) {
     Crypto,
     Logging,
     Telemetry,
+    Ci,
   ]
 }
 
@@ -394,5 +440,6 @@ pub fn category_label(category: Category) -> String {
     Crypto -> "Crypto"
     Logging -> "Logging"
     Telemetry -> "Telemetry"
+    Ci -> "CI"
   }
 }

--- a/packages/core/src/bygg/contribution.gleam
+++ b/packages/core/src/bygg/contribution.gleam
@@ -17,7 +17,10 @@ pub fn collect(names: List(String)) -> List(NamedContribution) {
         case c == empty() {
           True -> Error(Nil)
           False ->
-            Ok(NamedContribution(hex_name: package.hex_name, contribution: c))
+            Ok(NamedContribution(
+              hex_name: option.unwrap(package.hex_name, package.name),
+              contribution: c,
+            ))
         }
       }
       Error(_) -> Error(Nil)

--- a/packages/core/src/bygg/defaults.gleam
+++ b/packages/core/src/bygg/defaults.gleam
@@ -26,8 +26,11 @@ fn add_selected(config: ProjectConfig, name: String) -> ProjectConfig {
         dependencies: list.append(config.dependencies, [
           SelectedPackage(
             name: package.name,
-            hex_name: package.hex_name,
-            version_constraint: package.default_constraint,
+            hex_name: option.unwrap(package.hex_name, package.name),
+            version_constraint: option.unwrap(
+              package.default_constraint,
+              ">= 1.0.0 and < 2.0.0",
+            ),
           ),
         ]),
       )
@@ -48,8 +51,11 @@ fn add_selected_dev(config: ProjectConfig, name: String) -> ProjectConfig {
         dev_dependencies: list.append(config.dev_dependencies, [
           SelectedPackage(
             name: package.name,
-            hex_name: package.hex_name,
-            version_constraint: package.default_constraint,
+            hex_name: option.unwrap(package.hex_name, package.name),
+            version_constraint: option.unwrap(
+              package.default_constraint,
+              ">= 1.0.0 and < 2.0.0",
+            ),
           ),
         ]),
       )

--- a/packages/core/src/bygg/generator.gleam
+++ b/packages/core/src/bygg/generator.gleam
@@ -208,8 +208,28 @@ fn build_files(
       p.hex_name == "testcontainers_gleam"
     })
 
+  let ci_package_name =
+    list.append(config.dependencies, config.dev_dependencies)
+    |> list.find_map(fn(pkg) {
+      case catalog.find_by_name(pkg.name) {
+        Ok(p) ->
+          case p.category {
+            catalog.Ci -> Ok(p.name)
+            _ -> Error(Nil)
+          }
+        Error(_) -> Error(Nil)
+      }
+    })
+
+  let toml_config =
+    config.ProjectConfig(
+      ..config,
+      dependencies: filter_non_hex_packages(config.dependencies),
+      dev_dependencies: filter_non_hex_packages(config.dev_dependencies),
+    )
+
   let base_files: List(FileEntry) = [
-    FileEntry("gleam.toml", toml.render(config)),
+    FileEntry("gleam.toml", toml.render(toml_config)),
     FileEntry(
       "src/" <> config.name <> ".gleam",
       template.src_module(config, app_profile, contributions),
@@ -301,6 +321,21 @@ fn build_files(
     ]
   }
 
+  let ci_files: List(FileEntry) = case ci_package_name {
+    Error(_) -> []
+    Ok(name) -> {
+      let version = extract_gleam_version(config.gleam_version_constraint)
+      let path = case name {
+        "github_actions" -> ".github/workflows/ci.yml"
+        "gitlab_ci" -> ".gitlab-ci.yml"
+        "circleci" -> ".circleci/config.yml"
+        "travisci" -> ".travis.yml"
+        _ -> name <> ".yml"
+      }
+      [FileEntry(path, template.ci_config(name, version, has_testcontainers))]
+    }
+  }
+
   list.flatten([
     base_files,
     test_utils_files,
@@ -309,6 +344,7 @@ fn build_files(
     context_module_files,
     docker_files,
     dockerfile_files,
+    ci_files,
   ])
 }
 
@@ -340,11 +376,29 @@ fn ensure_dep(
           Ok(package) ->
             config.SelectedPackage(
               package.name,
-              package.hex_name,
-              package.default_constraint,
+              option.unwrap(package.hex_name, package.name),
+              option.unwrap(package.default_constraint, ">= 1.0.0 and < 2.0.0"),
             )
           Error(_) -> config.SelectedPackage(name, name, ">= 1.0.0 and < 2.0.0")
         },
       ])
+  }
+}
+
+fn filter_non_hex_packages(
+  packages: List(SelectedPackage),
+) -> List(SelectedPackage) {
+  list.filter(packages, fn(pkg) {
+    case catalog.find_by_name(pkg.name) {
+      Ok(catalog_pkg) -> option.is_some(catalog_pkg.default_constraint)
+      Error(_) -> True
+    }
+  })
+}
+
+fn extract_gleam_version(constraint: String) -> String {
+  case string.split(constraint, " ") {
+    [_, version, ..] -> version
+    _ -> constraint
   }
 }

--- a/packages/core/src/bygg/template.gleam
+++ b/packages/core/src/bygg/template.gleam
@@ -1,6 +1,7 @@
 import bygg/config.{type ProjectConfig}
 import bygg/contribution.{type NamedContribution}
 import bygg/profile.{type ApplicationProfile}
+import bygg/template/ci
 import bygg/template/config_module as config_module_template
 import bygg/template/context_module as context_module_template
 import bygg/template/docker
@@ -89,4 +90,12 @@ pub fn dockerfile(dockerfile_instructions: List(String)) -> String {
 
 pub fn context_module(context_fields: List(String)) -> String {
   context_module_template.render(context_fields)
+}
+
+pub fn ci_config(
+  name: String,
+  gleam_version: String,
+  needs_testcontainers: Bool,
+) -> String {
+  ci.render(name, gleam_version, needs_testcontainers)
 }

--- a/packages/core/src/bygg/template/ci.gleam
+++ b/packages/core/src/bygg/template/ci.gleam
@@ -1,0 +1,151 @@
+import gleam/string
+
+pub fn render(
+  name: String,
+  gleam_version: String,
+  needs_testcontainers: Bool,
+) -> String {
+  case name {
+    "github_actions" -> github_actions(gleam_version, needs_testcontainers)
+    "gitlab_ci" -> gitlab_ci(gleam_version, needs_testcontainers)
+    "circleci" -> circleci(gleam_version, needs_testcontainers)
+    "travisci" -> travisci(gleam_version, needs_testcontainers)
+    _ -> ""
+  }
+}
+
+fn github_actions(gleam_version: String, needs_testcontainers: Bool) -> String {
+  let elixir_line = case needs_testcontainers {
+    True -> "          elixir-version: \"1.17\"\n"
+    False -> ""
+  }
+  "name: CI
+
+on:
+  push:
+    branches: [\"main\"]
+  pull_request:
+    branches: [\"main\"]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: erlef/setup-beam@v1
+        with:
+          otp-version: \"27\"
+          rebar3-version: \"3\"
+          gleam-version: \"{gleam_version}\"
+{elixir_line}      - run: gleam build
+      - run: gleam test
+"
+  |> string.replace("{gleam_version}", gleam_version)
+  |> string.replace("{elixir_line}", elixir_line)
+}
+
+fn gitlab_ci(gleam_version: String, needs_testcontainers: Bool) -> String {
+  let services_block = case needs_testcontainers {
+    True -> "\nservices:\n  - docker:dind\n"
+    False -> ""
+  }
+  let variables_block = case needs_testcontainers {
+    True ->
+      "\nvariables:\n  DOCKER_HOST: tcp://docker:2376\n  DOCKER_TLS_CERTDIR: \"/certs\"\n"
+    False -> ""
+  }
+  let extra_packages = case needs_testcontainers {
+    True -> " elixir docker-cli"
+    False -> ""
+  }
+  "image: ghcr.io/gleam-lang/gleam:v{gleam_version}-erlang-alpine
+{services_block}{variables_block}
+before_script:
+  - apk add --no-cache rebar3{extra_packages}
+
+test:
+  script:
+    - gleam build
+    - gleam test
+"
+  |> string.replace("{gleam_version}", gleam_version)
+  |> string.replace("{services_block}", services_block)
+  |> string.replace("{variables_block}", variables_block)
+  |> string.replace("{extra_packages}", extra_packages)
+}
+
+fn circleci(gleam_version: String, needs_testcontainers: Bool) -> String {
+  case needs_testcontainers {
+    False ->
+      "version: 2.1
+
+jobs:
+  test:
+    docker:
+      - image: ghcr.io/gleam-lang/gleam:v{gleam_version}-erlang
+    steps:
+      - checkout
+      - run:
+          name: Install rebar3
+          command: apt-get update && apt-get install -y rebar3
+      - run: gleam build
+      - run: gleam test
+
+workflows:
+  ci:
+    jobs:
+      - test
+"
+      |> string.replace("{gleam_version}", gleam_version)
+    True ->
+      "version: 2.1
+
+jobs:
+  test:
+    machine:
+      image: ubuntu-2204:current
+    steps:
+      - checkout
+      - run:
+          name: Install Gleam
+          command: |
+            curl -fsSL https://github.com/gleam-lang/gleam/releases/download/v{gleam_version}/gleam-v{gleam_version}-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin
+      - run:
+          name: Install rebar3 and Elixir
+          command: apt-get update && apt-get install -y rebar3 elixir
+      - run: gleam build
+      - run: gleam test
+
+workflows:
+  ci:
+    jobs:
+      - test
+"
+      |> string.replace("{gleam_version}", gleam_version)
+  }
+}
+
+fn travisci(gleam_version: String, needs_testcontainers: Bool) -> String {
+  let services_block = case needs_testcontainers {
+    True -> "\nservices:\n  - docker\n"
+    False -> ""
+  }
+  let elixir_install = case needs_testcontainers {
+    True -> "  - sudo apt-get update && sudo apt-get install -y elixir\n"
+    False -> ""
+  }
+  "language: erlang
+otp_release:
+  - \"27\"
+{services_block}
+before_install:
+  - curl -fsSL https://github.com/gleam-lang/gleam/releases/download/v{gleam_version}/gleam-v{gleam_version}-x86_64-unknown-linux-musl.tar.gz | tar xz -C /usr/local/bin
+{elixir_install}
+script:
+  - gleam build
+  - gleam test
+"
+  |> string.replace("{gleam_version}", gleam_version)
+  |> string.replace("{services_block}", services_block)
+  |> string.replace("{elixir_install}", elixir_install)
+}

--- a/packages/core/test/bygg_core_test.gleam
+++ b/packages/core/test/bygg_core_test.gleam
@@ -228,10 +228,34 @@ pub fn catalog_sqlight_has_config_field_blocks_test() {
 
 fn with_dep(config: ProjectConfig, name: String) -> ProjectConfig {
   let pkg = case catalog.find_by_name(name) {
-    Ok(p) -> SelectedPackage(p.name, p.hex_name, p.default_constraint)
+    Ok(p) ->
+      SelectedPackage(
+        p.name,
+        option.unwrap(p.hex_name, p.name),
+        option.unwrap(p.default_constraint, ">= 1.0.0 and < 2.0.0"),
+      )
     Error(_) -> SelectedPackage(name, name, ">= 1.0.0 and < 2.0.0")
   }
   ProjectConfig(..config, dependencies: [pkg, ..config.dependencies])
+}
+
+fn with_dev_deps(config: ProjectConfig, names: List(String)) -> ProjectConfig {
+  let extra =
+    list.map(names, fn(name) {
+      case catalog.find_by_name(name) {
+        Ok(p) ->
+          SelectedPackage(
+            p.name,
+            option.unwrap(p.hex_name, p.name),
+            option.unwrap(p.default_constraint, ">= 1.0.0 and < 2.0.0"),
+          )
+        Error(_) -> SelectedPackage(name, name, ">= 1.0.0 and < 2.0.0")
+      }
+    })
+  ProjectConfig(
+    ..config,
+    dev_dependencies: list.append(config.dev_dependencies, extra),
+  )
 }
 
 pub fn snapshot_toml_basic_app_test() {
@@ -987,4 +1011,95 @@ pub fn snapshot_test_utils_shork_with_testcontainers_test() {
     |> should.be_ok()
   f.content
   |> birdie.snap(title: "test_utils_shork_with_testcontainers")
+}
+
+pub fn generator_github_actions_produces_ci_file_test() {
+  let config = config.default("my_app") |> with_dep("github_actions")
+  let assert Ok(project) = generator.generate(config)
+  project.files
+  |> list.map(fn(f) { f.path })
+  |> list.contains(".github/workflows/ci.yml")
+  |> should.be_true()
+}
+
+pub fn generator_ci_package_not_in_gleam_toml_test() {
+  let config = config.default("my_app") |> with_dep("github_actions")
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(toml_file) =
+    list.find(project.files, fn(f) { f.path == "gleam.toml" })
+  toml_file.content |> string.contains("github_actions") |> should.be_false()
+}
+
+pub fn snapshot_ci_github_actions_test() {
+  let config = config.default("my_app") |> with_dep("github_actions")
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) =
+    list.find(project.files, fn(f) { f.path == ".github/workflows/ci.yml" })
+  f.content |> birdie.snap(title: "ci_github_actions")
+}
+
+pub fn snapshot_ci_github_actions_with_testcontainers_test() {
+  let config =
+    config.default("my_app")
+    |> with_dep("github_actions")
+    |> with_dev_deps(["testcontainers_gleam"])
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) =
+    list.find(project.files, fn(f) { f.path == ".github/workflows/ci.yml" })
+  f.content |> birdie.snap(title: "ci_github_actions_with_testcontainers")
+}
+
+pub fn snapshot_ci_gitlab_test() {
+  let config = config.default("my_app") |> with_dep("gitlab_ci")
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) =
+    list.find(project.files, fn(f) { f.path == ".gitlab-ci.yml" })
+  f.content |> birdie.snap(title: "ci_gitlab")
+}
+
+pub fn snapshot_ci_gitlab_with_testcontainers_test() {
+  let config =
+    config.default("my_app")
+    |> with_dep("gitlab_ci")
+    |> with_dev_deps(["testcontainers_gleam"])
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) =
+    list.find(project.files, fn(f) { f.path == ".gitlab-ci.yml" })
+  f.content |> birdie.snap(title: "ci_gitlab_with_testcontainers")
+}
+
+pub fn snapshot_ci_circleci_test() {
+  let config = config.default("my_app") |> with_dep("circleci")
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) =
+    list.find(project.files, fn(f) { f.path == ".circleci/config.yml" })
+  f.content |> birdie.snap(title: "ci_circleci")
+}
+
+pub fn snapshot_ci_circleci_with_testcontainers_test() {
+  let config =
+    config.default("my_app")
+    |> with_dep("circleci")
+    |> with_dev_deps(["testcontainers_gleam"])
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) =
+    list.find(project.files, fn(f) { f.path == ".circleci/config.yml" })
+  f.content |> birdie.snap(title: "ci_circleci_with_testcontainers")
+}
+
+pub fn snapshot_ci_travisci_test() {
+  let config = config.default("my_app") |> with_dep("travisci")
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) = list.find(project.files, fn(f) { f.path == ".travis.yml" })
+  f.content |> birdie.snap(title: "ci_travisci")
+}
+
+pub fn snapshot_ci_travisci_with_testcontainers_test() {
+  let config =
+    config.default("my_app")
+    |> with_dep("travisci")
+    |> with_dev_deps(["testcontainers_gleam"])
+  let assert Ok(project) = generator.generate(config)
+  let assert Ok(f) = list.find(project.files, fn(f) { f.path == ".travis.yml" })
+  f.content |> birdie.snap(title: "ci_travisci_with_testcontainers")
 }

--- a/packages/core/test/integration_helpers.gleam
+++ b/packages/core/test/integration_helpers.gleam
@@ -83,7 +83,11 @@ pub fn with_deps(cfg: ProjectConfig, names: List(String)) -> ProjectConfig {
   let deps =
     list.map(names, fn(name) {
       let assert Ok(pkg) = catalog.find_by_name(name)
-      SelectedPackage(pkg.name, pkg.hex_name, pkg.default_constraint)
+      SelectedPackage(
+        pkg.name,
+        option.unwrap(pkg.hex_name, pkg.name),
+        option.unwrap(pkg.default_constraint, ">= 1.0.0 and < 2.0.0"),
+      )
     })
   config.ProjectConfig(..cfg, dependencies: deps)
 }
@@ -92,7 +96,11 @@ pub fn with_dev_deps(cfg: ProjectConfig, names: List(String)) -> ProjectConfig {
   let extra =
     list.map(names, fn(name) {
       let assert Ok(pkg) = catalog.find_by_name(name)
-      SelectedPackage(pkg.name, pkg.hex_name, pkg.default_constraint)
+      SelectedPackage(
+        pkg.name,
+        option.unwrap(pkg.hex_name, pkg.name),
+        option.unwrap(pkg.default_constraint, ">= 1.0.0 and < 2.0.0"),
+      )
     })
   config.ProjectConfig(
     ..cfg,

--- a/packages/web/src/bygg_web/model.gleam
+++ b/packages/web/src/bygg_web/model.gleam
@@ -15,6 +15,7 @@ pub type WizardStep {
   AskDatabase
   AskMessaging
   AskTesting
+  AskCi
   WizardDone
 }
 
@@ -31,6 +32,7 @@ pub type Model {
     db_choice: Option(String),
     msg_choice: Option(String),
     test_choices: Set(String),
+    ci_choice: Option(String),
     generate_error: Option(String),
     last_generated: Option(String),
   )
@@ -51,6 +53,7 @@ pub type Msg {
   WizardChoseDatabase(Option(String))
   WizardChoseMessaging(Option(String))
   WizardToggledTestTool(String)
+  WizardChoseCi(Option(String))
   WizardContinued
   WizardBack
   WizardApply
@@ -69,6 +72,7 @@ pub fn init(_flags: Nil) -> Model {
     db_choice: None,
     msg_choice: None,
     test_choices: set.new(),
+    ci_choice: None,
     generate_error: None,
     last_generated: None,
   )

--- a/packages/web/src/bygg_web/update.gleam
+++ b/packages/web/src/bygg_web/update.gleam
@@ -4,12 +4,12 @@ import bygg/config.{type SelectedPackage, SelectedPackage}
 import bygg/generator
 import bygg_web/effect as app_effect
 import bygg_web/model.{
-  type Model, type Msg, AskDatabase, AskMessaging, AskPurpose, AskTesting,
+  type Model, type Msg, AskCi, AskDatabase, AskMessaging, AskPurpose, AskTesting,
   DepsTab, GenerateFailed, GenerateSucceeded, Model, UserClickedGenerate,
   UserFilteredCategory, UserSelectedArchetype, UserSetProjectName, UserSetTarget,
   UserStartedOver, UserSwitchedTab, UserToggledDep, WizardAnsweredPurpose,
-  WizardApply, WizardBack, WizardChoseDatabase, WizardChoseMessaging,
-  WizardContinued, WizardDone, WizardToggledTestTool,
+  WizardApply, WizardBack, WizardChoseCi, WizardChoseDatabase,
+  WizardChoseMessaging, WizardContinued, WizardDone, WizardToggledTestTool,
 }
 import gleam/list
 import gleam/option.{None, Some}
@@ -116,7 +116,7 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
     WizardAnsweredPurpose(purpose) -> {
       let next_step = case purpose {
         "rest-api" | "ssr-website" -> AskDatabase
-        _ -> AskTesting
+        _ -> AskCi
       }
       #(
         Model(
@@ -149,7 +149,12 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
       #(Model(..model, test_choices: choices), effect.none())
     }
 
-    WizardContinued -> #(Model(..model, wizard_step: WizardDone), effect.none())
+    WizardChoseCi(choice) -> #(
+      Model(..model, ci_choice: choice, wizard_step: WizardDone),
+      effect.none(),
+    )
+
+    WizardContinued -> #(Model(..model, wizard_step: AskCi), effect.none())
 
     WizardBack -> {
       let prev = case model.wizard_step {
@@ -160,7 +165,12 @@ pub fn update(model: Model, msg: Msg) -> #(Model, Effect(Msg)) {
             Some("rest-api") | Some("ssr-website") -> AskMessaging
             _ -> AskPurpose
           }
-        WizardDone -> AskTesting
+        AskCi ->
+          case model.purpose {
+            Some("rest-api") | Some("ssr-website") -> AskTesting
+            _ -> AskPurpose
+          }
+        WizardDone -> AskCi
         AskPurpose -> AskPurpose
       }
       #(Model(..model, wizard_step: prev), effect.none())
@@ -223,7 +233,7 @@ fn apply_wizard_state(model: Model) -> Model {
   }
 
   let extra_deps =
-    [model.db_choice, model.msg_choice]
+    [model.db_choice, model.msg_choice, model.ci_choice]
     |> list.filter_map(fn(opt) { option.to_result(opt, Nil) })
     |> set.from_list
     |> set.union(model.test_choices)
@@ -240,6 +250,7 @@ fn apply_wizard_state(model: Model) -> Model {
     db_choice: None,
     msg_choice: None,
     test_choices: set.new(),
+    ci_choice: None,
   )
 }
 
@@ -249,8 +260,11 @@ fn resolve_deps(names: List(String)) -> List(SelectedPackage) {
       Ok(pkg) ->
         Ok(SelectedPackage(
           name: pkg.name,
-          hex_name: pkg.hex_name,
-          version_constraint: pkg.default_constraint,
+          hex_name: option.unwrap(pkg.hex_name, pkg.name),
+          version_constraint: option.unwrap(
+            pkg.default_constraint,
+            ">= 1.0.0 and < 2.0.0",
+          ),
         ))
       Error(_) -> Error(Nil)
     }

--- a/packages/web/src/bygg_web/view/deps.gleam
+++ b/packages/web/src/bygg_web/view/deps.gleam
@@ -1,5 +1,5 @@
 import bygg/catalog.{
-  type Category, type Package, BothTargets, ErlangOnly, FrontendFramework,
+  type Category, type Package, BothTargets, Ci, ErlangOnly, FrontendFramework,
   HttpServer, JavaScriptOnly, LustreComponent, LustreServerComponent,
   WebFramework,
 }
@@ -165,7 +165,12 @@ fn package_card(pkg: Package, model: Model) -> Element(Msg) {
           attribute("target", "_blank"),
           attribute("rel", "noopener noreferrer"),
         ],
-        [html.text("View repository →")],
+        [
+          html.text(case pkg.category {
+            Ci -> "Read more →"
+            _ -> "View repository →"
+          }),
+        ],
       ),
     ]),
   ])

--- a/packages/web/src/bygg_web/view/wizard.gleam
+++ b/packages/web/src/bygg_web/view/wizard.gleam
@@ -1,8 +1,9 @@
 import bygg/config.{Erlang, JavaScript}
 import bygg_web/model.{
-  type Model, type Msg, AskDatabase, AskMessaging, AskPurpose, AskTesting,
-  WizardAnsweredPurpose, WizardApply, WizardBack, WizardChoseDatabase,
-  WizardChoseMessaging, WizardContinued, WizardDone, WizardToggledTestTool,
+  type Model, type Msg, AskCi, AskDatabase, AskMessaging, AskPurpose, AskTesting,
+  WizardAnsweredPurpose, WizardApply, WizardBack, WizardChoseCi,
+  WizardChoseDatabase, WizardChoseMessaging, WizardContinued, WizardDone,
+  WizardToggledTestTool,
 }
 import bygg_web/view/shared
 import gleam/list
@@ -23,25 +24,25 @@ pub fn render(model: Model) -> Element(Msg) {
 fn step_indicator(model: Model) -> Element(Msg) {
   let steps = case model.purpose {
     option.Some("rest-api") | option.Some("ssr-website") -> [
-      "Purpose", "Database", "Messaging", "Testing", "Done",
+      "Purpose", "Database", "Messaging", "Testing", "CI", "Done",
     ]
-    option.Some(_) -> ["Purpose", "Testing", "Done"]
-    option.None -> ["Purpose", "Done"]
+    option.Some(_) -> ["Purpose", "CI", "Done"]
+    option.None -> ["Purpose", "CI", "Done"]
   }
   let current_idx = case model.wizard_step {
     AskPurpose -> 0
     AskDatabase -> 1
     AskMessaging -> 2
-    AskTesting ->
+    AskTesting -> 3
+    AskCi ->
       case model.purpose {
-        option.Some("rest-api") | option.Some("ssr-website") -> 3
+        option.Some("rest-api") | option.Some("ssr-website") -> 4
         _ -> 1
       }
     WizardDone ->
       case model.purpose {
-        option.Some("rest-api") | option.Some("ssr-website") -> 4
-        option.Some(_) -> 2
-        option.None -> 1
+        option.Some("rest-api") | option.Some("ssr-website") -> 5
+        _ -> 2
       }
   }
   html.div(
@@ -107,6 +108,7 @@ fn step_content(model: Model) -> Element(Msg) {
     AskDatabase -> ask_database(model)
     AskMessaging -> ask_messaging(model)
     AskTesting -> ask_testing(model)
+    AskCi -> ask_ci(model)
     WizardDone -> wizard_done(model)
   }
 }
@@ -263,30 +265,15 @@ fn ask_messaging(model: Model) -> Element(Msg) {
 }
 
 fn ask_testing(model: Model) -> Element(Msg) {
-  let erlang_path = case model.purpose {
-    option.Some("rest-api") | option.Some("ssr-website") -> True
-    _ -> False
-  }
-  let tools = case erlang_path {
-    True -> [
-      #(
-        "birdie",
-        "birdie",
-        "Snapshot testing — assert exact output and approve changes",
-      ),
+  let tools = case model.purpose {
+    option.Some("rest-api") | option.Some("ssr-website") -> [
       #(
         "testcontainers_gleam",
         "testcontainers",
         "Spin up Docker containers (Postgres, etc.) in your tests",
       ),
     ]
-    False -> [
-      #(
-        "birdie",
-        "birdie",
-        "Snapshot testing — assert exact output and approve changes",
-      ),
-    ]
+    _ -> []
   }
   html.div([], [
     html.h2([class("text-xl font-bold text-stone-900 mb-2")], [
@@ -304,6 +291,40 @@ fn ask_testing(model: Model) -> Element(Msg) {
       }),
     ),
     nav_row([back_btn(), continue_btn()]),
+  ])
+}
+
+fn ask_ci(model: Model) -> Element(Msg) {
+  let choices = [
+    #(
+      option.Some("github_actions"),
+      "GitHub Actions",
+      "Generate .github/workflows/ci.yml",
+    ),
+    #(option.Some("gitlab_ci"), "GitLab CI/CD", "Generate .gitlab-ci.yml"),
+    #(option.Some("circleci"), "CircleCI", "Generate .circleci/config.yml"),
+    #(option.Some("travisci"), "Travis CI", "Generate .travis.yml"),
+  ]
+  html.div([], [
+    html.h2([class("text-xl font-bold text-stone-900 mb-2")], [
+      html.text("Set up CI?"),
+    ]),
+    html.p([class("text-stone-500 text-sm mb-6")], [
+      html.text("Select a CI provider or skip to continue without one."),
+    ]),
+    html.div(
+      [class("grid grid-cols-1 sm:grid-cols-2 gap-3")],
+      list.map(choices, fn(choice) {
+        let #(key, title, desc) = choice
+        shared.radio_card(
+          model.ci_choice == key,
+          WizardChoseCi(key),
+          title,
+          desc,
+        )
+      }),
+    ),
+    nav_row([back_btn(), skip_btn(WizardChoseCi(option.None))]),
   ])
 }
 
@@ -333,9 +354,15 @@ fn wizard_done(model: Model) -> Element(Msg) {
           option.Some(m) -> summary_row("Messaging", m)
           option.None -> shared.nothing()
         },
-        ..list.map(set.to_list(model.test_choices), fn(t) {
-          summary_row("Testing", t)
-        })
+        ..list.append(
+          list.map(set.to_list(model.test_choices), fn(t) {
+            summary_row("Testing", t)
+          }),
+          case model.ci_choice {
+            option.Some(ci) -> [summary_row("CI", ci)]
+            option.None -> []
+          },
+        )
       ],
     ),
     html.div([class("flex gap-3 mt-6")], [
@@ -451,6 +478,7 @@ fn int_to_string(n: Int) -> String {
     3 -> "3"
     4 -> "4"
     5 -> "5"
+    6 -> "6"
     _ -> "?"
   }
 }


### PR DESCRIPTION
Add support for selecting CI providers (GitHub Actions, GitLab CI,
CircleCI, Travis CI) in the project wizard. CI packages are now
treated as non-Hex packages and excluded from gleam.toml. Make
hex_name and default_constraint optional in the catalog to support
non-Hex packages. Generate CI configuration files based on user
selection and testcontainers dependency presence.